### PR TITLE
fix ts_config

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "assemblyscript/std/assembly.json",
+  "extends": "../node_modules/assemblyscript/std/assembly.json",
   "include": [
     "./*.ts",
     "./**/*.ts",


### PR DESCRIPTION
Types after installing assembly script should extend the tsconfig.json in ../node_modules/assemblyscript/std/assembly.json so when people install assembly script on their project tsconfig automatically picks up the dir.