### PR TITLE
update method selector to match OP_20_ABI.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export function defineSelectors(): void {
     ABIRegistry.defineGetterSelector('name', false);
     ABIRegistry.defineGetterSelector('symbol', false);
     ABIRegistry.defineGetterSelector('totalSupply', false);
-    ABIRegistry.defineGetterSelector('maxSupply', false);
+    ABIRegistry.defineGetterSelector('maximumSupply', false);
 
     /** Optional */
     ABIRegistry.defineMethodSelector('airdrop', true);


### PR DESCRIPTION
[OP_20_ABI.ts](https://github.com/btc-vision/opnet/blob/main/src/abi/shared/json/OP_20_ABI.ts)

Op_20 abi (which the wallet uses) defines "maximumSupply", while the OP_20 repo defines "maxSupply". 

This might result in the wallet not picking up tokens made with the repo because the abis dont match.